### PR TITLE
feat: Add hight Score

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,9 +4,16 @@ let btns = ["yellow", "red", "purple", "green"];
 
 let started = false;
 let level = 0;
+let highScore = parseInt(localStorage.getItem("simonHighScore"), 10) || 0;
 
 let h2 = document.querySelector(".h2txt");
 let boxes = document.querySelectorAll(".box");
+let highScoreEl = document.getElementById("highScoreValue");
+
+function updateHighScoreDisplay() {
+    highScoreEl.textContent = highScore;
+}
+updateHighScoreDisplay();
 
 // Start Game
 document.addEventListener("keypress", function(){
@@ -29,6 +36,12 @@ function levelUp(){
     userSq = [];
     level++;
     h2.innerText = `Level ${level}`;
+
+    if (level > highScore) {
+        highScore = level;
+        localStorage.setItem("simonHighScore", highScore);
+        updateHighScoreDisplay();
+    }
 
     let randomIdx = Math.floor(Math.random() * 4);
     let randomColor = btns[randomIdx];

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 
    <div class="cntr">
      <h1>Simon Game</h1>
+     <p class="high-score">High score: <span id="highScoreValue">0</span></p>
      <h2 class="h2txt">Press any key to start</h2>
 
      <div class="btn-cntnr">

--- a/style.css
+++ b/style.css
@@ -19,6 +19,12 @@ h1{
     color: rgb(30, 210, 150);
 }
 
+.high-score {
+    margin: 0 0 8px 0;
+    font-size: 1rem;
+    color: #333;
+}
+
 .btn-cntnr{
     display: grid;
     grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
Close #2 

Added a high score that shows as "High score: X" on screen and is stored in localStorage so it survives restarts and closing the browser. The high score only updates when the current level beats the previous record (checked in levelUp()). Implemented with a new HTML element, JS logic for load/save/compare, and a small CSS style for the label.

<img width="488" height="611" alt="image" src="https://github.com/user-attachments/assets/a61ad07f-6118-4c6f-86dc-ddc4a494468f" />
